### PR TITLE
switch to using a subtree for openstack-common

### DIFF
--- a/chef/cookbooks/openstack-common/.gitignore
+++ b/chef/cookbooks/openstack-common/.gitignore
@@ -1,0 +1,8 @@
+.bundle/
+.cookbooks/
+.kitchen
+.vagrant
+.coverage/
+*.swp
+Berksfile.lock
+Vagrantfile

--- a/chef/cookbooks/openstack-common/.gitreview
+++ b/chef/cookbooks/openstack-common/.gitreview
@@ -1,0 +1,4 @@
+[gerrit]
+host=review.openstack.org
+port=29418
+project=stackforge/cookbook-openstack-common.git

--- a/chef/cookbooks/openstack-common/.rubocop.yml
+++ b/chef/cookbooks/openstack-common/.rubocop.yml
@@ -22,3 +22,6 @@ LineLength:
 
 WordArray:
   MinSize: 3
+
+MethodLength:
+  Max: 15

--- a/chef/cookbooks/openstack-common/CHANGELOG.md
+++ b/chef/cookbooks/openstack-common/CHANGELOG.md
@@ -1,6 +1,16 @@
 # CHANGELOG for cookbook-openstack-common
 
 This file is used to list changes made in each version of cookbook-openstack-common.
+
+## 9.6.0
+* Add an option to store passwords in attributes instead of data bags. Deprecates the get_secret method and the development_mode.
+
+## 9.5.2
+* Adds new python_packages attributes for database client packages
+
+## 9.5.1
+* Add Trove endpoints, database and mq attributes
+
 ## 9.5.0
 * Add new image_id cli library method for obtaining glance ID from image name
 

--- a/chef/cookbooks/openstack-common/README.md
+++ b/chef/cookbooks/openstack-common/README.md
@@ -229,7 +229,7 @@ License and Author
 | **Copyright**        |  Copyright (c) 2012-2013, AT&T Services, Inc.      |
 | **Copyright**        |  Copyright (c) 2013, Opscode, Inc.                 |
 | **Copyright**        |  Copyright (c) 2013, Craig Tracey                  |
-| **Copyright**        |  Copyright (c) 2013, SUSE Linux GmbH               |
+| **Copyright**        |  Copyright (c) 2013-2014, SUSE Linux GmbH          |
 | **Copyright**        |  Copyright (c) 2013-2014, IBM, Corp.               |
 | **Copyright**        |  Copyright (c) 2013-2014, Rackspace US, Inc.       |
 

--- a/chef/cookbooks/openstack-common/attributes/database.rb
+++ b/chef/cookbooks/openstack-common/attributes/database.rb
@@ -4,7 +4,7 @@
 # Attributes:: database
 #
 # Copyright 2012-2013, AT&T Services, Inc.
-# Copyright 2013, SUSE Linux GmbH
+# Copyright 2013-2014, SUSE Linux GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -194,3 +194,23 @@ default['openstack']['db']['root_user_use_databag'] = false
 # If above root_user_use_databag is true, the below string
 # will be passed to the get_password library routine.
 default['openstack']['db']['root_user_key'] = 'mysqlroot'
+
+# platform and DBMS-specific python client packages
+case node['platform_family']
+when 'rhel'
+  default['openstack']['db']['python_packages'] = {
+    :mysql => ['MySQL-python'],
+    :db2 => ['python-ibm-db', 'python-ibm-db-sa'],
+    :postgresql => ['python-psycopg2']
+  }
+when 'suse'
+  default['openstack']['db']['python_packages'] = {
+    :mysql => ['python-mysql'],
+    :postgresql => ['python-psycopg2']
+  }
+when 'debian'
+  default['openstack']['db']['python_packages'] = {
+    :mysql => ['python-mysqldb'],
+    :postgresql => ['python-psycopg2']
+  }
+end

--- a/chef/cookbooks/openstack-common/attributes/default.rb
+++ b/chef/cookbooks/openstack-common/attributes/default.rb
@@ -4,7 +4,7 @@
 # Attributes:: default
 #
 # Copyright 2012-2013, AT&T Services, Inc.
-# Copyright 2013, SUSE Linux GmbH
+# Copyright 2013-2014, SUSE Linux GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -34,7 +34,23 @@ default['openstack']['common']['custom_template_banner'] = '
 # pass = secret "passwords", "nova"
 #
 # The value of pass will be "nova"
+#
+# This attribute is now DEPRECATED and will be removed. Use the default
+# attributes below instead.
 default['openstack']['developer_mode'] = false
+
+# Use data bags for storing passwords
+# Set this to false in order to get the passwords from attributes like:
+# node['openstack']['secret'][key][type]
+default['openstack']['use_databags'] = true
+
+# Default attributes when not using data bags (use_databags = false)
+%w{block-storage object-storage compute database dashboard image identity
+   telemetry network object-storage orchestration}.each do |service|
+  %w{user service db token}.each do |type|
+    default['openstack']['secret'][service][type] = "#{service}-#{type}"
+  end
+end
 
 # The type of token signing to use (uuid or pki)
 default['openstack']['auth']['strategy'] = 'pki'
@@ -365,7 +381,7 @@ default['openstack']['endpoints']['database-api-bind']['bind_interface'] = nil
 default['openstack']['endpoints']['database-api']['host'] = node['openstack']['endpoints']['host']
 default['openstack']['endpoints']['database-api']['scheme'] = 'http'
 default['openstack']['endpoints']['database-api']['port'] = '8779'
-default['openstack']['endpoints']['database-api']['path'] = '/v1'
+default['openstack']['endpoints']['database-api']['path'] = '/v1.0'
 default['openstack']['endpoints']['database-api']['bind_interface'] = nil
 
 # Alternately, if you used some standardized DNS naming scheme, you could

--- a/chef/cookbooks/openstack-common/attributes/messaging.rb
+++ b/chef/cookbooks/openstack-common/attributes/messaging.rb
@@ -4,7 +4,7 @@
 # Attributes:: messaging
 #
 # Copyright 2012-2013, AT&T Services, Inc.
-# Copyright 2013, SUSE Linux GmbH
+# Copyright 2013-2014, SUSE Linux GmbH
 # Copyright 2013-2014, Rackspace US, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,7 +34,8 @@ default['openstack']['endpoints']['mq']['bind_interface'] = nil
 ###################################################################
 # Services to assign mq attributes for
 ###################################################################
-services = %w{block-storage compute database image telemetry network orchestration}
+services = %w{block-storage compute database image
+              telemetry network orchestration}
 
 ###################################################################
 # Generic default attributes

--- a/chef/cookbooks/openstack-common/libraries/endpoints.rb
+++ b/chef/cookbooks/openstack-common/libraries/endpoints.rb
@@ -43,8 +43,7 @@ module ::Openstack # rubocop:disable Documentation
 
   # Instead of specifying the verbose node['openstack']['db'][service],
   # this shortcut allows the simpler and shorter db(service), where
-  # service is one of 'compute', 'image', 'identity', 'network', 'dashboard'
-  # 'orchestration', 'telemetry' 'block-storage' and 'volume'
+  # service can be: 'compute', 'image', 'identity', 'network', etc.
   def db(service)
     node['openstack']['db'][service]
   rescue

--- a/chef/cookbooks/openstack-common/metadata.rb
+++ b/chef/cookbooks/openstack-common/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@lists.tfoundry.com'
 license          'Apache 2.0'
 description      'Common OpenStack attributes, libraries and recipes.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '9.5.0'
+version          '9.6.0'
 
 recipe           'openstack-common', 'Installs/Configures common recipes'
 recipe           'openstack-common::set_endpoints_by_interface', 'Set endpoints by interface'

--- a/chef/cookbooks/openstack-common/spec/password_spec.rb
+++ b/chef/cookbooks/openstack-common/spec/password_spec.rb
@@ -11,103 +11,101 @@ describe 'openstack-common::default' do
 
     include_context 'library-stubs'
 
-    describe '#secret' do
-      it 'returns index param when developer_mode is true' do
-        node.set['openstack']['developer_mode'] = true
-        expect(subject.secret('passwords', 'nova')).to eq('nova')
+    context 'stored in data bags by default' do
+      describe '#secret' do
+        it 'returns databag' do
+          value = { 'nova' => 'this' }
+          ::Chef::EncryptedDataBagItem.stub(:load_secret).with('/etc/chef/openstack_data_bag_secret').and_return('secret')
+          ::Chef::EncryptedDataBagItem.stub(:load).with('passwords', 'nova', 'secret').and_return(value)
+          expect(subject.secret('passwords', 'nova')).to eq('this')
+        end
       end
 
-      it 'returns the specified password when developer_mode is true' do
-        node.set['openstack']['developer_mode'] = true
-        node.override['openstack']['secret']['nova'] = '12345'
-        expect(subject.secret('passwords', 'nova')).to eq('12345')
+      describe '#get_secret' do
+        it 'returns databag value' do
+          value = { 'nova' => 'this' }
+          ::Chef::EncryptedDataBagItem.stub(:load_secret).with('/etc/chef/openstack_data_bag_secret').and_return('secret')
+          ::Chef::EncryptedDataBagItem.stub(:load).with('secrets', 'nova', 'secret').and_return(value)
+          expect(subject.get_secret('nova')).to eq('this')
+        end
+
+        it 'returns secret from an alternate databag when secrets_data_bag set' do
+          node.set['openstack']['secret']['secrets_data_bag'] = 'myothersecrets'
+          value = { 'nova' => 'this' }
+          ::Chef::EncryptedDataBagItem.stub(:load_secret).with('/etc/chef/openstack_data_bag_secret').and_return('secret')
+          ::Chef::EncryptedDataBagItem.stub(:load).with('myothersecrets', 'nova', 'secret').and_return(value)
+          expect(subject.get_secret('nova')).to eq('this')
+        end
       end
 
-      it 'returns databag when developer_mode is false' do
-        value = { 'nova' => 'this' }
-        ::Chef::EncryptedDataBagItem.stub(:load_secret).with('/etc/chef/openstack_data_bag_secret').and_return('secret')
-        ::Chef::EncryptedDataBagItem.stub(:load).with('passwords', 'nova', 'secret').and_return(value)
-        expect(subject.secret('passwords', 'nova')).to eq('this')
-      end
-    end
+      describe '#get_password' do
+        ['service', 'db', 'user'].each do |type|
+          it "returns databag value for #{type}" do
+            value = { 'nova' => 'this' }
+            ::Chef::EncryptedDataBagItem.stub(:load_secret).with('/etc/chef/openstack_data_bag_secret').and_return('secret')
+            ::Chef::EncryptedDataBagItem.stub(:load).with("#{type}_passwords", 'nova', 'secret').and_return(value)
+            expect(subject.get_password(type, 'nova')).to eq('this')
+          end
+        end
 
-    describe '#get_secret' do
-      it 'returns index param when developer_mode is true' do
-        node.set['openstack']['developer_mode'] = true
-        expect(subject.get_secret('nova')).to eq('nova')
-      end
+        it 'returns nil for an invalid type' do
+          expect(subject.get_password('invalid_type', 'nova')).to be_nil
+        end
 
-      it 'returns the specified password when developer_mode is true' do
-        node.set['openstack']['developer_mode'] = true
-        node.override['openstack']['secret']['nova'] = '67890'
-        expect(subject.get_secret('nova')).to eq('67890')
-      end
-
-      it 'returns databag when developer_mode is false' do
-        value = { 'nova' => 'this' }
-        ::Chef::EncryptedDataBagItem.stub(:load_secret).with('/etc/chef/openstack_data_bag_secret').and_return('secret')
-        ::Chef::EncryptedDataBagItem.stub(:load).with('secrets', 'nova', 'secret').and_return(value)
-        expect(subject.get_secret('nova')).to eq('this')
-      end
-
-      it 'returns secret from an alternate databag when secrets_data_bag set' do
-        node.set['openstack']['secret']['secrets_data_bag'] = 'myothersecrets'
-        value = { 'nova' => 'this' }
-        ::Chef::EncryptedDataBagItem.stub(:load_secret).with('/etc/chef/openstack_data_bag_secret').and_return('secret')
-        ::Chef::EncryptedDataBagItem.stub(:load).with('myothersecrets', 'nova', 'secret').and_return(value)
-        expect(subject.get_secret('nova')).to eq('this')
-      end
-    end
-
-    describe '#get_password_service_password' do
-      it 'returns index param when developer_mode is true' do
-        node.set['openstack']['developer_mode'] = true
-        expect(subject.get_password('service', 'nova')).to eq('nova')
-      end
-
-      it 'returns databag when developer_mode is false' do
-        value = { 'nova' => 'this' }
-        ::Chef::EncryptedDataBagItem.stub(:load_secret).with('/etc/chef/openstack_data_bag_secret').and_return('secret')
-        ::Chef::EncryptedDataBagItem.stub(:load).with('service_passwords', 'nova', 'secret').and_return(value)
-        expect(
-          subject.get_password('service', 'nova')
-        ).to eq('this')
+        it 'returns tokens from the secrets_data_bag' do
+          bag_content = { 'nova' => 'mysecret' }
+          ::Chef::EncryptedDataBagItem.stub(:load_secret).with(
+            '/etc/chef/openstack_data_bag_secret').and_return('secret')
+          ::Chef::EncryptedDataBagItem.stub(:load).with(
+            'secrets', 'nova', 'secret').and_return(bag_content)
+          expect(subject.get_password('token', 'nova')).to eq('mysecret')
+        end
       end
     end
 
-    describe '#get_password_db_password' do
-      it 'returns index param when developer_mode is true' do
-        node.set['openstack']['developer_mode'] = true
-        expect(
-          subject.get_password('db', 'nova')
-        ).to eq('nova')
-      end
+    context 'stored in attributes as an alternative' do
+      before { node.set['openstack']['use_databags'] = false }
 
-      it 'returns databag when developer_mode is false' do
-        value = { 'nova' => 'this' }
-        ::Chef::EncryptedDataBagItem.stub(:load_secret).with('/etc/chef/openstack_data_bag_secret').and_return('secret')
-        ::Chef::EncryptedDataBagItem.stub(:load).with('db_passwords', 'nova', 'secret').and_return(value)
-        expect(
-          subject.get_password('db', 'nova')
-        ).to eq('this')
+      describe '#get_password' do
+        %w{service db user token}.each do |type|
+          it "returns the set attribute for #{type}" do
+            expect(subject.get_password(type, 'compute')).to eq("compute-#{type}")
+          end
+        end
       end
     end
 
-    describe '#get_password_user_password' do
-      it 'returns index param when developer_mode is true' do
-        node.set['openstack']['developer_mode'] = true
-        expect(
-          subject.get_password('user', 'nova')
-        ).to eq('nova')
+    describe 'developer_mode' do
+      before { node.set['openstack']['developer_mode'] = true }
+
+      describe '#secret' do
+        it 'returns index param' do
+          expect(subject.secret('passwords', 'nova')).to eq('nova')
+        end
+
+        it 'returns the specified password' do
+          node.override['openstack']['secret']['nova'] = '12345'
+          expect(subject.secret('passwords', 'nova')).to eq('12345')
+        end
       end
 
-      it 'returns databag when developer_mode is false' do
-        value = { 'nova' => 'this' }
-        ::Chef::EncryptedDataBagItem.stub(:load_secret).with('/etc/chef/openstack_data_bag_secret').and_return('secret')
-        ::Chef::EncryptedDataBagItem.stub(:load).with('user_passwords', 'nova', 'secret').and_return(value)
-        expect(
-          subject.get_password('user', 'nova')
-        ).to eq('this')
+      describe '#get_secret' do
+        it 'returns index param' do
+          expect(subject.get_secret('nova')).to eq('nova')
+        end
+
+        it 'returns the specified password' do
+          node.override['openstack']['secret']['nova'] = '67890'
+          expect(subject.get_secret('nova')).to eq('67890')
+        end
+      end
+
+      describe '#get_password' do
+        ['service', 'db', 'user'].each do |type|
+          it "returns index param for #{type}" do
+            expect(subject.get_password(type, 'nova')).to eq('nova')
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This is a proposal to track the upstream openstack-common cookbook in a SUSE-Cloud repository where we can make any needed adjustments (such as backporting to ruby 1.8). We then use that repository as a subtree here.

This pull-request looks awful. You can see it better at:
https://github.com/mapleoin/barclamp-trove/commits/common-subtree It's actually just those three commits from today, but it also adds in the subtree which I guess is what makes github blow up.
