### PR TITLE
change the volume_support default to False

### DIFF
--- a/chef/cookbooks/trove/attributes/default.rb
+++ b/chef/cookbooks/trove/attributes/default.rb
@@ -20,7 +20,7 @@
 default[:trove][:verbose] = true
 default[:trove][:debug] = false
 
-default[:trove][:volume_support] = true
+default[:trove][:volume_support] = false
 
 default[:trove][:service_user] = 'trove'
 default[:trove][:service_password] = 'trove'

--- a/chef/data_bags/crowbar/bc-template-trove.json
+++ b/chef/data_bags/crowbar/bc-template-trove.json
@@ -10,7 +10,7 @@
       "swift_instance": "none",
       "cinder_instance": "none",
       "rabbitmq_instance": "none",
-      "volume_support": true,
+      "volume_support": false,
       "db": {
         "password": "",
         "user": "trove",

--- a/crowbar_framework/app/models/trove_service.rb
+++ b/crowbar_framework/app/models/trove_service.rb
@@ -38,7 +38,7 @@ class TroveService < ServiceObject
     base["attributes"][@bc_name]["keystone_instance"] = find_dep_proposal("keystone")
     base["attributes"][@bc_name]["nova_instance"] = find_dep_proposal("nova")
     base["attributes"][@bc_name]["cinder_instance"] = find_dep_proposal("cinder")
-    base["attributes"][@bc_name]["swift_instance"] = find_dep_proposal("swift")
+    base["attributes"][@bc_name]["swift_instance"] = find_dep_proposal("swift", true)
     base["attributes"][@bc_name]["rabbitmq_instance"] = find_dep_proposal("rabbitmq")
     base["attributes"][@bc_name]["db"]["password"] = random_password
 
@@ -51,12 +51,11 @@ class TroveService < ServiceObject
     answer << { "barclamp" => "keystone", "inst" => role.default_attributes[@bc_name]["keystone_instance"] }
     answer << { "barclamp" => "nova", "inst" => role.default_attributes[@bc_name]["nova_instance"] }
     answer << { "barclamp" => "cinder", "inst" => role.default_attributes[@bc_name]["cinder_instance"] }
-    answer << { "barclamp" => "swift", "inst" => role.default_attributes[@bc_name]["swift_instance"] }
     answer << { "barclamp" => "rabbitmq", "inst" => role.default_attributes[@bc_name]["rabbitmq_instance"] }
-    answer
-  end
+    if role.default_attributes[@bc_name]["volume_support"]
+      answer << { "barclamp" => "swift", "inst" => role.default_attributes[@bc_name]["swift_instance"] }
+    end
 
-  def validate_proposal_after_save proposal
-    validate_one_for_role proposal, "trove-server"
+    answer
   end
 end


### PR DESCRIPTION
With volume_support enabled, trove will require that new instances use
swift. It works fine without swift though and I suppose we want to avoid
an unneeded dependency on swift.
