### PR TITLE
sync openstack-database version from upstream

### DIFF
--- a/chef/cookbooks/openstack-database/CHANGELOG.md
+++ b/chef/cookbooks/openstack-database/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the cookbook-openstack
 
 ## 9.0.1
 * Allow setting passwords via attributes by using the get_password method
+* bump berkshelf to 2.0.18 to allow Supermarket support
+* fix fauxhai version for suse
 
 ## 9.0.0
 * Initial release of cookbook-openstack-database for Icehouse

--- a/chef/cookbooks/openstack-database/metadata.rb
+++ b/chef/cookbooks/openstack-database/metadata.rb
@@ -9,7 +9,6 @@ recipe           'openstack-database::identity_registration', 'Registers Trove e
 recipe           'openstack-database::api', 'Installs API service'
 recipe           'openstack-database::conductor', 'Installs Conductor service'
 recipe           'openstack-database::taskmanager', 'Installs TaskManager service'
-recipe           'openstack-database::guestagent', 'Installs GuestAgent service'
 
 depends          'openstack-common', '~> 9.6'
 depends          'openstack-identity', '~> 9.0'

--- a/chef/cookbooks/openstack-database/recipes/conductor.rb
+++ b/chef/cookbooks/openstack-database/recipes/conductor.rb
@@ -38,8 +38,8 @@ end
 db_user = node['openstack']['db']['database']['username']
 db_pass = get_password 'db', 'database'
 db_uri = db_uri('database', db_user, db_pass).to_s
-rabbit_pass = get_password(
-  'user', node['openstack']['mq']['database']['rabbit']['userid'])
+rabbit = node['openstack']['mq']['database']['rabbit']
+rabbit_pass = get_password('user', rabbit['userid'])
 identity_uri = endpoint('identity-api')
 
 template '/etc/trove/trove-conductor.conf' do
@@ -50,6 +50,7 @@ template '/etc/trove/trove-conductor.conf' do
   variables(
     :database_connection => db_uri,
     :identity_uri => identity_uri,
+    :rabbit => rabbit,
     :rabbit_pass => rabbit_pass
     )
 

--- a/chef/cookbooks/openstack-database/spec/conductor-suse_spec.rb
+++ b/chef/cookbooks/openstack-database/spec/conductor-suse_spec.rb
@@ -29,8 +29,16 @@ describe 'openstack-database::conductor' do
     end
 
     it 'has the default values for configurable attributes' do
-      [%r{^sql_connection = mysql://trove:db-pass@127.0.0.1:3306/trove\?charset=utf8$},
-       %r{^trove_auth_url = http://127.0.0.1:5000/v2.0$}
+      [/^debug = false$/,
+       /^verbose = false$/,
+       %r{^sql_connection = mysql://trove:db-pass@127.0.0.1:3306/trove\?charset=utf8$},
+       %r{^trove_auth_url = http://127.0.0.1:5000/v2.0$},
+       /^rabbit_host = 127.0.0.1$/,
+       /^rabbit_virtual_host = \/$/,
+       /^rabbit_port = 5672$/,
+       /^rabbit_userid = guest$/,
+       /^rabbit_password = rabbit-pass$/,
+       /^rabbit_use_ssl = false$/
       ].each do |content|
         expect(chef_run).to render_file(filename).with_content(content)
       end

--- a/chef/cookbooks/openstack-database/spec/identity_registration-suse_spec.rb
+++ b/chef/cookbooks/openstack-database/spec/identity_registration-suse_spec.rb
@@ -66,9 +66,9 @@ describe 'openstack-database::identity_registration' do
           :bootstrap_token => 'bootstrap-token',
           :service_type => 'database',
           :endpoint_region => 'RegionOne',
-          :endpoint_adminurl => 'http://127.0.0.1:8779/v1.0',
-          :endpoint_internalurl => 'http://127.0.0.1:8779/v1.0',
-          :endpoint_publicurl => 'http://127.0.0.1:8779/v1.0'
+          :endpoint_adminurl => 'http://127.0.0.1:8779/v1.0/%(tenant_id)s',
+          :endpoint_internalurl => 'http://127.0.0.1:8779/v1.0/%(tenant_id)s',
+          :endpoint_publicurl => 'http://127.0.0.1:8779/v1.0/%(tenant_id)s'
         )
       end
     end

--- a/chef/cookbooks/openstack-database/spec/spec_helper.rb
+++ b/chef/cookbooks/openstack-database/spec/spec_helper.rb
@@ -4,18 +4,18 @@ require 'chefspec'
 require 'chefspec/berkshelf'
 require 'chef/application'
 
-::LOG_LEVEL = :fatal
-::SUSE_OPTS = {
+LOG_LEVEL = :fatal
+SUSE_OPTS = {
   :platform => 'suse',
-  :version => '11.03',
+  :version => '11.3',
   :log_level => ::LOG_LEVEL
 }
-::REDHAT_OPTS = {
+REDHAT_OPTS = {
   :platform => 'redhat',
   :version => '6.5',
   :log_level => ::LOG_LEVEL
 }
-::UBUNTU_OPTS = {
+UBUNTU_OPTS = {
   :platform => 'ubuntu',
   :version => '12.04',
   :log_level => ::LOG_LEVEL

--- a/chef/cookbooks/openstack-database/spec/taskmanager-suse_spec.rb
+++ b/chef/cookbooks/openstack-database/spec/taskmanager-suse_spec.rb
@@ -43,7 +43,8 @@ describe 'openstack-database::taskmanager' do
        %r{^cinder_url = http://127.0.0.1:8776/v1/$},
        %r{^swift_url = http://127.0.0.1:8080/v1/$},
        %r{^dns_auth_url = http://127.0.0.1:5000/v2.0$},
-       %r{^log_dir = /var/log/trove}
+       %r{^log_dir = /var/log/trove},
+       /^trove_volume_support = true$/
       ].each do |content|
         expect(chef_run).to render_file(filename).with_content(content)
       end

--- a/chef/cookbooks/openstack-database/templates/default/trove-conductor.conf.erb
+++ b/chef/cookbooks/openstack-database/templates/default/trove-conductor.conf.erb
@@ -1,10 +1,21 @@
 <%= node["openstack"]["database"]["custom_template_banner"] %>
 
 [DEFAULT]
+verbose = <%= node["openstack"]["database"]["verbose"] %>
+debug = <%= node["openstack"]["database"]["debug"] %>
 control_exchange = trove
 trove_auth_url = <%= @identity_uri %>
 nova_proxy_admin_user = <%= node['openstack']['database']['nova_proxy_user'] %>
 nova_proxy_admin_pass = <%= node['openstack']['database']['nova_proxy_password'] %>
 nova_proxy_admin_tenant_name = <%= node['openstack']['database']['nova_proxy_tenant'] %>
 sql_connection = <%= @database_connection %>
+
+# AMQP Connection info
+rabbit_host = <%= @rabbit['host'] %>
+rabbit_userid = <%= @rabbit['userid'] %>
 rabbit_password = <%= @rabbit_pass %>
+rabbit_virtual_host = <%= @rabbit['vhost'] %>
+rabbit_port = <%= @rabbit['port'] %>
+rabbit_use_ssl = <%= @rabbit['use_ssl'] %>
+
+log_dir = /var/log/trove

--- a/chef/cookbooks/openstack-database/templates/default/trove-taskmanager.conf.erb
+++ b/chef/cookbooks/openstack-database/templates/default/trove-taskmanager.conf.erb
@@ -17,7 +17,6 @@ rabbit_password = <%= @rabbit_pass %>
 rabbit_virtual_host = <%= @rabbit['vhost'] %>
 rabbit_port = <%= @rabbit['port'] %>
 rabbit_use_ssl = <%= @rabbit['use_ssl'] %>
-rabbit_notification_topic = <%= @rabbit['notification_topic'] %>
 
 # SQLAlchemy connection string for the reference implementation
 # registry server. Any valid SQLAlchemy connection string is fine.
@@ -44,7 +43,7 @@ cinder_url = <%= @block_storage_uri %>
 swift_url = <%= @object_storage_uri %>
 
 # Config options for enabling volume service
-trove_volume_support = True
+trove_volume_support = <%= node['openstack']['database']['volume_support'] %>
 block_device_mapping = vdb
 device_path = /dev/vdb
 mount_point = /var/lib/mysql

--- a/chef/cookbooks/openstack-database/templates/default/trove.conf.erb
+++ b/chef/cookbooks/openstack-database/templates/default/trove.conf.erb
@@ -45,7 +45,7 @@ sql_idle_timeout = 3600
 db_api_implementation = "trove.db.sqlalchemy.api"
 
 # Path to the extensions
-api_extensions_path = trove/extensions/routes
+api_extensions_path = $pybasedir/extensions/routes
 
 # Configuration options for talking to nova via the novaclient.
 trove_auth_url = <%= @identity_uri %>


### PR DESCRIPTION
- set debug/verbose in trove-conductor.conf
- set rabbitmq configuration values in trove-conductor.conf
- add tenant_id to endpoint urls
- fix api_extensions_path by using a path relative to the pybasedir
- make trove_volume_support in trove-taskmanager.conf configurable
