### PR TITLE
set use_nova_server_config_drive to true

### DIFF
--- a/chef/cookbooks/openstack-database/attributes/default.rb
+++ b/chef/cookbooks/openstack-database/attributes/default.rb
@@ -58,3 +58,5 @@ default['openstack']['database']['api']['auth']['cache_dir'] = '/var/cache/trove
 default['openstack']['database']['nova_proxy_user'] = 'admin'
 default['openstack']['database']['nova_proxy_password'] = 'admin'
 default['openstack']['database']['nova_proxy_tenant'] = 'admin'
+
+default['openstack']['database']['use_nova_server_config_drive'] = false

--- a/chef/cookbooks/openstack-database/spec/taskmanager-suse_spec.rb
+++ b/chef/cookbooks/openstack-database/spec/taskmanager-suse_spec.rb
@@ -38,6 +38,7 @@ describe 'openstack-database::taskmanager' do
        /^rabbit_userid = guest$/,
        /^rabbit_password = rabbit-pass$/,
        /^rabbit_use_ssl = false$/,
+       /^use_nova_server_config_drive = false$/,
        %r{^trove_auth_url = http://127.0.0.1:5000/v2.0$},
        %r{^nova_compute_url = http://127.0.0.1:8774/v2/$},
        %r{^cinder_url = http://127.0.0.1:8776/v1/$},

--- a/chef/cookbooks/openstack-database/templates/default/trove-taskmanager.conf.erb
+++ b/chef/cookbooks/openstack-database/templates/default/trove-taskmanager.conf.erb
@@ -50,6 +50,11 @@ mount_point = /var/lib/mysql
 volume_time_out=30
 server_delete_time_out=480
 
+# Nova server boot options
+# sets the --config-drive argument when doing a nova boot
+# (controls how file injection is handled by nova)
+use_nova_server_config_drive = <%= node['openstack']['database']['use_nova_server_config_drive'] %>
+
 # Configuration options for talking to nova via the novaclient.
 # These options are for an admin user in your keystone config.
 # It proxy's the token received from the user to send to nova via this admin users creds,

--- a/chef/cookbooks/trove/recipes/default.rb
+++ b/chef/cookbooks/trove/recipes/default.rb
@@ -24,6 +24,8 @@ end
 node.set['openstack']['database']['verbose'] = node[:trove][:verbose]
 node.set['openstack']['database']['debug'] = node[:trove][:debug]
 node.set['openstack']['database']['volume_support'] = node[:trove][:volume_support]
+# we need this in order for nova file injection to work for trove
+node.set['openstack']['database']['use_nova_server_config_drive'] = true
 
 keystone_server = get_instance('roles:keystone-server')
 Chef::Log.info("Found keystone-server instance on #{keystone_server}.")


### PR DESCRIPTION
This allows nova file injection via config_drive to work which is needed
when trove adds configuration files to newly created instances via
cloud-init.

Note: the code to set this attribute is being backported in our Icehouse packages, but upstream does not have it in Icehouse, so the patches to openstack-database can also not go upstream. This nuisance will go away in Juno, but in the meantime, I don't know of a better way to handle this.
