### PR TITLE
Explicit include openstack-common::messaging

### DIFF
--- a/chef/cookbooks/openstack-identity/attributes/default.rb
+++ b/chef/cookbooks/openstack-identity/attributes/default.rb
@@ -20,6 +20,8 @@
 # limitations under the License.
 #
 
+include_attribute "openstack-common::messaging"
+
 # Set to some text value if you want templated config files
 # to contain a custom banner at the top of the written file
 default['openstack']['identity']['custom_template_banner'] = "


### PR DESCRIPTION
The attributes from this file need to be accessable to prevent

undefined method `[]' for nil:NilClass
54>> case node['openstack']['mq']['service_type']
