### PR TITLE
Use region from keystone settings

### DIFF
--- a/chef/cookbooks/trove/recipes/default.rb
+++ b/chef/cookbooks/trove/recipes/default.rb
@@ -91,6 +91,7 @@ node.set['openstack']['mq']['database']['rabbit']['userid'] = rabbitmq[:trove][:
 node.set['openstack']['mq']['database']['rabbit']['vhost'] = rabbitmq[:trove][:vhost]
 node.set['openstack']['secret'][rabbitmq[:trove][:user]]['user'] = rabbitmq[:trove][:password]
 
+node.set['openstack']['region'] = keystone_settings['endpoint_region']
 # XXX mysql configuration
 # this part should go away once trove supports postgresl
 


### PR DESCRIPTION
The keystone barclamp got the possibility to set a custom region
name. This name must be used by other barclamps as well.

related to: https://bugzilla.novell.com/show_bug.cgi?id=896481

(cherry picked from commit 041b2fecaac48c7598017794a9b025e0e78cf236)
