### PR TITLE
Skip db_sync run on SUSE

### DIFF
--- a/chef/cookbooks/openstack-database/recipes/api.rb
+++ b/chef/cookbooks/openstack-database/recipes/api.rb
@@ -96,5 +96,8 @@ template '/etc/trove/api-paste.ini' do
 end
 
 execute 'trove-manage db_sync' do
+  user  node['openstack']['database']['user']
+  group node['openstack']['database']['group']
+
   notifies :restart, 'service[trove-api]', :immediately
-end
+end unless node.platform == "suse"

--- a/chef/cookbooks/openstack-database/recipes/api.rb
+++ b/chef/cookbooks/openstack-database/recipes/api.rb
@@ -32,6 +32,12 @@ platform_options['api_packages'].each do |pkg|
   package pkg
 end
 
+file '/var/log/trove/trove-manage.log' do
+    owner node['openstack']['database']['user']
+    group node['openstack']['database']['group']
+    mode 00700
+end
+
 service 'trove-api' do
   service_name platform_options['api_service']
   supports :status => true, :restart => true
@@ -100,4 +106,5 @@ execute 'trove-manage db_sync' do
   group node['openstack']['database']['group']
 
   notifies :restart, 'service[trove-api]', :immediately
+# Skip run on SUSE. FIXME: needs to be readded once HA support is implemented
 end unless node.platform == "suse"


### PR DESCRIPTION
It is already run by the init script, and since it runs
with the wrong user, it screws everything up.