### PR TITLE
Adapt rubygem-mysql to the new name schema

### DIFF
--- a/chef/cookbooks/trove/recipes/default.rb
+++ b/chef/cookbooks/trove/recipes/default.rb
@@ -98,7 +98,14 @@ node.set['openstack']['region'] = keystone_settings['endpoint_region']
 # rubygem-mysql is installed here, although it would normally be the
 # database cookbook's responsibility. The database cookbook uses a
 # special mysql-chef_gem for this which is Chef 0.11 only.
-['mysql', 'python-mysql', 'rubygem-mysql'].each do |pkg|
+pkgs = ['mysql', 'python-mysql']
+if node["platform"] == "suse" && node["platform_version"].to_f >= 12 ||
+   node["platform"] == "opensuse" && node["platform_version"].to_f >= 13.2
+  pkgs.push("ruby#{node["languages"]["ruby"]["version"].to_f}-rubygem-mysql")
+else
+  pkgs.push("rubygem-mysql")
+end
+pkgs.each do |pkg|
   package pkg
 end
 


### PR DESCRIPTION
Use the new schema for rubygem in SLE12 and openSUSE 13.2.
