### PR TITLE
Backport trove random password

### DIFF
--- a/chef/data_bags/crowbar/bc-template-trove.json
+++ b/chef/data_bags/crowbar/bc-template-trove.json
@@ -11,6 +11,7 @@
       "cinder_instance": "none",
       "rabbitmq_instance": "none",
       "volume_support": false,
+      "service_user": "trove",
       "db": {
         "password": "",
         "user": "trove",
@@ -22,7 +23,7 @@
     "trove": {
       "crowbar-revision": 1,
       "crowbar-applied": false,
-      "schema-revision": 1,
+      "schema-revision": 2,
       "element_states": {
         "trove-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/bc-template-trove.json
+++ b/chef/data_bags/crowbar/bc-template-trove.json
@@ -22,6 +22,7 @@
     "trove": {
       "crowbar-revision": 1,
       "crowbar-applied": false,
+      "schema-revision": 1,
       "element_states": {
         "trove-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/bc-template-trove.schema
+++ b/chef/data_bags/crowbar/bc-template-trove.schema
@@ -47,6 +47,7 @@
             "crowbar-status": { "type": "str" },
             "crowbar-failed": { "type": "str" },
             "crowbar-queued": { "type": "bool" },
+            "schema-revision": { "type": "int" },
             "element_states": {
               "type": "map",
               "mapping": {

--- a/chef/data_bags/crowbar/bc-template-trove.schema
+++ b/chef/data_bags/crowbar/bc-template-trove.schema
@@ -20,6 +20,8 @@
             "swift_instance": { "type": "str", "required": true },
             "rabbitmq_instance": { "type": "str", "required": true },
             "volume_support": { "type": "bool", "required": true },
+            "service_user": { "type": "str", "required": true },
+            "service_password": { "type": "str" },
             "db": {
               "type": "map",
               "required": true,

--- a/chef/data_bags/crowbar/migrate/trove/001_add_configurable_db_attrs.rb
+++ b/chef/data_bags/crowbar/migrate/trove/001_add_configurable_db_attrs.rb
@@ -1,12 +1,14 @@
 def upgrade ta, td, a, d
-  a['trove']['db'] = {}
-  a['trove']['db']['password'] = nil
-  a['trove']['db']['user'] = 'trove'
-  a['trove']['db']['database'] = 'trove'
+  unless a["trove"].key? "db"
+    a["trove"]["db"] = {}
+    a["trove"]["db"]["password"] = nil
+    a["trove"]["db"]["user"] = "trove"
+    a["trove"]["db"]["database"] = "trove"
+  end
   return a, d
 end
 
 def downgrade ta, td, a, d
-  a['trove'].delete 'db'
+  a["trove"].delete 'db'
   return a, d
 end

--- a/chef/data_bags/crowbar/migrate/trove/001_add_configurable_db_attrs.rb
+++ b/chef/data_bags/crowbar/migrate/trove/001_add_configurable_db_attrs.rb
@@ -1,14 +1,14 @@
 def upgrade ta, td, a, d
-  unless a["trove"].key? "db"
-    a["trove"]["db"] = {}
-    a["trove"]["db"]["password"] = nil
-    a["trove"]["db"]["user"] = "trove"
-    a["trove"]["db"]["database"] = "trove"
+  unless a.key? "db"
+    a["db"] = {}
+    a["db"]["password"] = nil
+    a["db"]["user"] = "trove"
+    a["db"]["database"] = "trove"
   end
   return a, d
 end
 
 def downgrade ta, td, a, d
-  a["trove"].delete 'db'
+  a.delete 'db'
   return a, d
 end

--- a/chef/data_bags/crowbar/migrate/trove/002_add_service_details.rb
+++ b/chef/data_bags/crowbar/migrate/trove/002_add_service_details.rb
@@ -1,0 +1,16 @@
+def upgrade(ta, td, a, d)
+  # Use a class variable, since migrations are run twice.
+  unless defined?(@@trove_service_password)
+    service = ServiceObject.new "fake-logger"
+    @@trove_service_password = service.random_password
+  end
+  a["service_user"] = ta["service_user"]
+  a["service_password"] = @@trove_service_password
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("service_user")
+  a.delete("service_password")
+  return a, d
+end

--- a/crowbar_framework/app/models/trove_service.rb
+++ b/crowbar_framework/app/models/trove_service.rb
@@ -45,6 +45,7 @@ class TroveService < ServiceObject
     base["attributes"][@bc_name]["swift_instance"] = find_dep_proposal("swift", true)
     base["attributes"][@bc_name]["rabbitmq_instance"] = find_dep_proposal("rabbitmq")
     base["attributes"][@bc_name]["db"]["password"] = random_password
+    base["attributes"][@bc_name]["service_password"] = random_password
 
     # assign a default node to the trove-server role
     nodes = NodeObject.all


### PR DESCRIPTION
Cherry-pick the two commits from crowbar-openstack to set the trove service password to random. I'm a little concerned about the changes required to the first database migration, however without @toabctl's commit, any trove migration would be a no-op so I don't think it was actually successfully run on any release prior to 7.
